### PR TITLE
README.md nits

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Positionals:
 
 Multiple input files are read as if they were one large file.
 This allows (for example) a "prologue" file to contain xml2rfc specific definitions,
-to be included before the main rst file.
+to be included before the main RST file.
 
 The following subsections provide more details on the contents
 of RST files.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ of RST files.
 
 To generate an rfc2xml header, the `header` directive must be included.
 
-```
+```rst
 .. header::
 ```
 
@@ -58,7 +58,7 @@ This directive must appear after any xml2rfc specific definitions discussed belo
 The `replace` directive is used to configure xml2rfc specific definitions.
 The general syntax is:
 
-```
+```rst
 .. |name| replace:: value
 ```
 
@@ -75,7 +75,7 @@ where `name` is a string defined below, and `value` is the value to set it to.
 
 Example:
 
-```
+```rst
 .. |docName| replace:: draft-thaler-sample-00
 .. |ipr| replace:: trust200902
 .. |category| replace:: std
@@ -102,7 +102,7 @@ The document must have at least one author, and can have multiple authors.
 
 Example:
 
-```
+```rst
 .. |author[0].fullname| replace:: John Doe
 .. |author[0].role| replace:: editor
 .. |author[0].surname| replace:: Doe
@@ -119,7 +119,7 @@ used to group fields of the same author.
 
 RST files specify external references using the following syntax:
 
-```
+```rst
 `Some Title <https://example.com/path#optional-fragment-id>`_
 ```
 
@@ -133,7 +133,7 @@ portion as follows:
 
 Example:
 
-```
+```rst
 .. |ref[SAMPLE].title| replace:: Sample Title
 .. |ref[SAMPLE].target| replace:: https://example.com/target
 .. |ref[SAMPLE].type| replace:: normative

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ of RST files.
 
 ### Header directive
 
-To generate an rfc2xml header, the header directive must be included.
+To generate an rfc2xml header, the `header` directive must be included.
 
 ```
 .. header::
@@ -55,23 +55,23 @@ This directive must appear after any xml2rfc specific definitions discussed belo
 
 ### xml2rfc specific definitions
 
-The "replace" directive is used to configure xml2rfc specific definitions.
+The `replace` directive is used to configure xml2rfc specific definitions.
 The general syntax is:
 
 ```
 .. |name| replace:: value
 ```
 
-where 'name' is a string defined below, and 'value' is the value to set it to.
+where `name` is a string defined below, and `value` is the value to set it to.
 
 #### Common settings
 
-* docName: The filename of the draft without any extension.
-* ipr: The ipr value, such as "trust200902".
-* category: The category, such as "std".
-* titleAbbr: Abbreviated title to appear in the page header.
-* submissionType: The stream name, such as "IETF".
-* baseTargetUri: Base URI for any external references whose target is a relative URI reference.
+* `docName`: The filename of the draft without any extension.
+* `ipr`: The ipr value, such as `trust200902`.
+* `category`: The category, such as `std`.
+* `titleAbbr`: Abbreviated title to appear in the page header.
+* `submissionType`: The stream name, such as `IETF`.
+* `baseTargetUri`: Base URI for any external references whose target is a relative URI reference.
 
 Example:
 
@@ -88,17 +88,17 @@ Example:
 
 The document must have at least one author, and can have multiple authors.
 
-* author[_anchor_].fullname: Fullname to associate with the author with the indicated _anchor_.
-* author[_anchor_].role: Optional. Role to associate with the author with the indicated _anchor_.
-* author[_anchor_].surname: Surname to associate with the author with the indicated _anchor_.
-* author[_anchor_].initials: Initials to associate with the author with the indicated _anchor_.
-* author[_anchor_].email: Optional. Email address to associate with the author with the indicated _anchor_.
-* author[_anchor_].phone: Optional. Phone number to associate with the author with the indicated _anchor_.
-* author[_anchor_].city: Optional. City to associate with the author with the indicated _anchor_.
-* author[_anchor_].code: Optional. Postal code to associate with the author with the indicated _anchor_.
-* author[_anchor_].country: Optional. Country to associate with the author with the indicated _anchor_.
-* author[_anchor_].region: Optional. State or region to associate with the author with the indicated _anchor_.
-* author[_anchor_].street: Optional. Street address to associate with the author with the indicated _anchor_.
+* `author[<anchor>].fullname`: Fullname to associate with the author with the indicated `<anchor>`.
+* `author[<anchor>].role`: Optional. Role to associate with the author with the indicated `<anchor>`.
+* `author[<anchor>].surname`: Surname to associate with the author with the indicated `<anchor>`.
+* `author[<anchor>].initials`: Initials to associate with the author with the indicated `<anchor>`.
+* `author[<anchor>].email`: Optional. Email address to associate with the author with the indicated `<anchor>`.
+* `author[<anchor>].phone`: Optional. Phone number to associate with the author with the indicated `<anchor>`.
+* `author[<anchor>].city`: Optional. City to associate with the author with the indicated `<anchor>`.
+* `author[<anchor>].code`: Optional. Postal code to associate with the author with the indicated `<anchor>`.
+* `author[<anchor>].country`: Optional. Country to associate with the author with the indicated `<anchor>`.
+* `author[<anchor>].region`: Optional. State or region to associate with the author with the indicated `<anchor>`.
+* `author[<anchor>].street`: Optional. Street address to associate with the author with the indicated `<anchor>`.
 
 Example:
 
@@ -112,7 +112,7 @@ Example:
 .. |author[0].city| replace:: Anytown
 ```
 
-The _anchor_ values do not appear in the XML but are merely
+The `<anchor>` values do not appear in the XML but are merely
 used to group fields of the same author.
 
 #### External References
@@ -126,10 +126,10 @@ RST files specify external references using the following syntax:
 To specify the Internet-Draft format reference, one must map the URI (not including the fragment)
 portion as follows:
 
-* ref[_anchor_].target: Target URI to associate with the reference with the indicated _anchor_. If the target
-  is a relative reference, it is relative to the "baseTargetUri" specified above.
-* ref[_anchor_].title: Title to associate with the reference with the indicated _anchor_.
-* ref[_anchor_].type: Must be set to "normative" or "informative".
+* `ref[<anchor>].target`: Target URI to associate with the reference with the indicated `<anchor>`. If the target
+  is a relative reference, it is relative to the `baseTargetUri` specified above.
+* `ref[<anchor>].title`: Title to associate with the reference with the indicated `<anchor>`.
+* `ref[<anchor>].type`: Must be set to `normative` or `informative`.
 
 Example:
 


### PR DESCRIPTION
## PR

Here are a few minor nits for the README file.

## Other feedback

### Acronyms

I find the multiple acronyms a bit confusing, possibly because I'm not familiar with the IETF toolchain.

- The name of the project itself is not clear to me. `rst2rfcxml` implies we are converting to `rfcxml`, is this the name of the XML variant used for RFCs? I thought we were converting into “some XML that xml2rfc can ingest`, so I more or less expected `rst2xmlrfc` instead.
- The README.md mentions “xml2rfc specific definitions”, `xml2rfc` being the tool, this looks OK.
- The repo description and intro mentions “Convert reStructured Text to rfc2xml Version 3.” -> Isn't it `xml2rfc` instead of `rfc2xml`?
- “To generate an rfc2xml header” -> Same, I thought it would be `xml2rfc`.

I'm probably confused about the vocabulary.

### Building

... was straightforward and worked well on Linux. If anything, might be worth adding a line to mention where the binary is located after the build.

### Running

After realising that I had to fix your prologue for the instruction set with regards to commit https://github.com/dthaler/rst2rfcxml/commit/eeded486a148a881b18427daa9b17d656a1449b4, I managed to run successfully:

```
$ ./build/rst2rfcxml/rst2rfcxml instruction-set-prologue.rst instruction-set.rst -o foo.xml
$ xml2rfc --html foo.xml
$ firefox foo.html
```

The rendered version looks neat! I haven't looked at the details yet, but haven't spotted anything that looks wrong. I haven't tried to edit the source RST files either to test the limits of the RST parsing, but I understand the tool is very new anyway. I'll try to come back to it in the next few days.