### PR TITLE
Fix typos in name of xml2rfc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rst2rfcxml
-Convert [reStructured Text](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html)
-to [rfc2xml Version 3](https://www.rfc-editor.org/rfc/rfc7991).
+Convert [reStructured Text (RST)](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html)
+to [xml2rfc Version 3](https://www.rfc-editor.org/rfc/rfc7991).
 
 ## Installation
 Clone:
@@ -24,7 +24,7 @@ cmake --build build --config Release
 ## Usage
 
 ```
-A reStructured Text to xmlrfc Version 3 converter
+A reStructured Text to xml2rfc Version 3 converter
 Usage: rst2rfcxml.exe [OPTIONS] input...
 
 Positionals:
@@ -40,12 +40,20 @@ Multiple input files are read as if they were one large file.
 This allows (for example) a "prologue" file to contain xml2rfc specific definitions,
 to be included before the main RST file.
 
+For example, conversion from RST files to an Internet-Draft might be done as follows:
+
+```
+$ ./build/rst2rfcxml/rst2rfcxml sample-prologue.rst sample.rst -o draft-thaler-sample-00.xml
+$ xml2rfc --html draft-thaler-sample-00.xml
+$ firefox draft-thaler-sample-00.html
+```
+
 The following subsections provide more details on the contents
 of RST files.
 
 ### Header directive
 
-To generate an rfc2xml header, the `header` directive must be included.
+To generate an xml2rfc header, the `header` directive must be included.
 
 ```rst
 .. header::

--- a/rst2rfcxml/main.cpp
+++ b/rst2rfcxml/main.cpp
@@ -8,7 +8,7 @@ using namespace std;
 
 int main(int argc, char** argv)
 {
-	CLI::App app{ "A reStructured Text to xmlrfc Version 3 converter" };
+	CLI::App app{ "A reStructured Text to rfc2xml Version 3 converter" };
 	string output_filename;
 	app.add_option("-o", output_filename, "Output filename");
 	vector<string> input_filenames;


### PR DESCRIPTION
Addresses feedback raised by @qmonnet in https://github.com/dthaler/rst2rfcxml/pull/17.
I did not change the name of the project as I think "rst2xml2rfc" would be misleading by sounding like it converts rst all the way to rfc.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>