### PR TITLE
Fix mismatch in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,6 @@ Example:
 
 ```rst
 .. |ref[SAMPLE].title| replace:: Sample Title
-.. |ref[SAMPLE].target| replace:: https://example.com/target
+.. |ref[SAMPLE].target| replace:: https://example.com/path
 .. |ref[SAMPLE].type| replace:: normative
 ```


### PR DESCRIPTION
"target" vs "path" were both used in README.md.  This PR fixes them to match.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>