### PR TITLE
Fix bug with indented tables

### DIFF
--- a/lib/rst2rfcxml.cpp
+++ b/lib/rst2rfcxml.cpp
@@ -604,6 +604,7 @@ rst2rfcxml::handle_table_line(string current, string next, ostream& output_strea
 
         // Find column indices.
         size_t index = current.find_first_of("=");
+        _column_indices.clear();
         while (index != string::npos) {
             _column_indices.push_back(index);
             index = current.find_first_not_of("=", index);


### PR DESCRIPTION
Hit a crash with an indented table due to not having the correct column count
when an indented table appears after a section heading that uses `==========` style.