### PR TITLE
Support "#." for ordered lists

### DIFF
--- a/lib/rst2rfcxml.cpp
+++ b/lib/rst2rfcxml.cpp
@@ -755,10 +755,14 @@ rst2rfcxml::process_line(string current, string next, ostream& output_stream)
         return 0;
     }
     if (current.starts_with(".. admonition:: ")) {
+        // Pop contexts until SECTION.
+        while ((_contexts.size() > 0) && (_contexts.top() != xml_context::SECTION)) {
+            pop_context(output_stream);
+        }
+
         push_context(output_stream, xml_context::ASIDE);
-        push_context(output_stream, xml_context::TEXT);
         string name = handle_escapes_and_links(current.substr(16));
-        output_stream << fmt::format("{}<strong>{}</strong>", _spaces(_contexts.size()), name) << endl;
+        output_stream << fmt::format("{}<t><strong>{}</strong></t>", _spaces(_contexts.size()), name) << endl;
         push_context(output_stream, xml_context::CONSUME_BLANK_LINE);
         return 0;
     }
@@ -899,7 +903,8 @@ void
 rst2rfcxml::output_line(string line, ostream& output_stream)
 {
     cmatch match;
-    if (regex_search(line.c_str(), match, regex("^[\\d]+\\. "))) {
+    if (regex_search(line.c_str(), match, regex("^[\\d]+\\. ")) ||
+        regex_search(line.c_str(), match, regex("^#. "))) {
         if (in_context(xml_context::LIST_ELEMENT)) {
             pop_context(output_stream);
         }

--- a/test/basic_tests.cpp
+++ b/test/basic_tests.cpp
@@ -159,8 +159,8 @@ TEST_CASE("aside", "[basic]")
 Done with admonition.
 )",
         R"(<aside>
+ <t><strong>Example</strong></t>
  <t>
-  <strong>Example</strong>
   This is an example.
  </t>
 </aside>
@@ -524,6 +524,24 @@ TEST_CASE("ordered list", "[basic]")
         R"(
 1. One
 2. Two
+)",
+        R"(<ol>
+ <li>
+  One
+ </li>
+ <li>
+  Two
+ </li>
+</ol>
+)");
+}
+
+TEST_CASE("ordered list with hash", "[basic]")
+{
+    test_rst2rfcxml(
+        R"(
+#. One
+#. Two
 )",
         R"(<ol>
  <li>


### PR DESCRIPTION
This also fixes a bug where aside is not under `<section>` but deeper in the xml tree.