### PR TITLE
Add support for xref relative references, and line blocks

### DIFF
--- a/lib/rst2rfcxml.cpp
+++ b/lib/rst2rfcxml.cpp
@@ -866,7 +866,7 @@ rst2rfcxml::process_line(string current, string next, ostream& output_stream)
         output_header(output_stream);
         return 0;
     }
-    if (current == ".. code-block::") {
+    if (current.starts_with(".. code-block::") && current.find_first_not_of(" ", 15) == std::string::npos) {
         if (in_context(xml_context::TEXT)) {
             pop_context(output_stream);
         }
@@ -1048,6 +1048,14 @@ rst2rfcxml::output_line(string indented_line, ostream& output_stream)
                       << endl;
     } else if (in_context(xml_context::COMMENT)) {
         output_stream << _spaces(_contexts.size()) << _handle_escapes(line) << endl;
+    } else if (line.starts_with("|")) {
+        // Handle line blocks, preserving leading whitespace.
+        string value = (line.length() > 1) ? line.substr(2) : "";
+        size_t count = value.find_first_not_of(" ");
+        if (count == std::string::npos) {
+            count = 0;
+        }
+        output_stream << _spaces(count) << handle_escapes_and_links(value) << "<br/>" << endl;
     } else if ((current_indentation != string::npos)) {
         if (current_indentation > context_indentation) {
             if (in_context(xml_context::DEFINITION_TERM)) {

--- a/test/basic_tests.cpp
+++ b/test/basic_tests.cpp
@@ -99,6 +99,22 @@ TEST_CASE("titles", "[basic]")
     test_rst2rfcxml("Foo\n~~~\n", "<section anchor=\"foo\" title=\"Foo\">\n</section>\n");
 }
 
+TEST_CASE("line block", "[basic]")
+{
+    test_rst2rfcxml(
+        R"(
+|  First line
+| Second line
+|
+|  Fourth line
+)",
+        R"( First line<br/>
+Second line<br/>
+<br/>
+ Fourth line<br/>
+)");
+}
+
 TEST_CASE("code block", "[basic]")
 {
     test_rst2rfcxml(

--- a/test/basic_tests.cpp
+++ b/test/basic_tests.cpp
@@ -40,8 +40,10 @@ TEST_CASE("escapes", "[basic]")
 
 TEST_CASE("references", "[basic]")
 {
+    // Citation without reference details.
     test_rst2rfcxml("`Foo bar`_", "<t>\n <xref target=\"foo-bar\">Foo bar</xref>\n</t>\n");
 
+    // Citation with reference details.
     test_rst2rfcxml(
         R"(
 .. |ref[SAMPLE].target| replace:: https://example.com/target
@@ -49,12 +51,45 @@ TEST_CASE("references", "[basic]")
 )",
         "<t>\n <xref target=\"SAMPLE\">Sample reference</xref>\n</t>\n");
 
-        test_rst2rfcxml(
+    // Fragment as part of the reference link itself.
+    test_rst2rfcxml(
+        R"(
+.. |ref[SAMPLE].target| replace:: https://example.com/target#fragment
+`Sample reference <https://example.com/target#fragment>`_
+)",
+        "<t>\n <xref target=\"SAMPLE\">Sample reference</xref>\n</t>\n");
+
+    // Non-RFC reference with fragment.
+    test_rst2rfcxml(
         R"(
 .. |ref[SAMPLE].target| replace:: https://example.com/target
 `Sample reference <https://example.com/target#fragment>`_
 )",
-        "<t>\n <relref target=\"SAMPLE\" section=\"\" relative=\"fragment\" derivedLink=\"https://example.com/target#fragment\">Sample reference</relref>\n</t>\n");
+        "<t>\n <xref target=\"SAMPLE\" section=\"fragment\" relative=\"#fragment\">Sample reference</xref>\n</t>\n");
+}
+
+TEST_CASE("rfc references", "[basic]")
+{
+    test_rst2rfcxml(
+        R"(
+.. |ref[RFC8126].target| replace:: https://www.rfc-editor.org/rfc/rfc8126.html
+See `RFC 8126 section 4 <https://www.rfc-editor.org/rfc/rfc8126.html#section-4>`_ for details.
+)",
+        "<t>\n See <xref target=\"RFC8126\" section=\"4\"/> for details.\n</t>\n");
+
+    test_rst2rfcxml(
+        R"(
+.. |ref[RFC8126].target| replace:: https://www.rfc-editor.org/rfc/rfc8126.html
+See `RFC 8126, section 4 <https://www.rfc-editor.org/rfc/rfc8126.html#section-4>`_ for details.
+)",
+        "<t>\n See <xref target=\"RFC8126\" section=\"4\"/> for details.\n</t>\n");
+
+    test_rst2rfcxml(
+        R"(
+.. |ref[RFC8126].target| replace:: https://www.rfc-editor.org/rfc/rfc8126.html
+See `Section 4 of RFC 8126 <https://www.rfc-editor.org/rfc/rfc8126.html#section-4>`_ for details.
+)",
+        "<t>\n See <xref target=\"RFC8126\" section=\"4\"/> for details.\n</t>\n");
 }
 
 TEST_CASE("titles", "[basic]")


### PR DESCRIPTION
* [Change from relref to xref for deep references](https://github.com/dthaler/rst2rfcxml/commit/1de524edb9e93ba08c70dea10bb41ed6d9510990)
* [Add support for line blocks](https://github.com/dthaler/rst2rfcxml/commit/6581d8c3390055bc1bc28abe24627bfe1576e792)

Fixes #117