### PR TITLE
Switch macos build to -14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
     strategy:
       matrix:
         configurations: [Debug, Release]
-    runs-on: macos-12
+    runs-on: macos-14
     env:
       # Configuration type to build.  For documentation on how build matrices work, see
       # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix


### PR DESCRIPTION
macos 12 is deprecated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Upgraded the macOS runner version to enhance compatibility and performance.
	- Updated Windows build configuration to ensure the correct build settings are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->