### PR TITLE
Move to ubuntu-latest for coveralls in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         configurations: [Debug, Release]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       # Configuration type to build.  For documentation on how build matrices work, see
       # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix


### PR DESCRIPTION
Github is removing 20.04

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the CI/CD pipeline to the latest Ubuntu environment, ensuring the build process benefits from the most recent system updates and tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->