### PR TITLE
Include directive must only use files in the same directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ $ xml2rfc --html draft-thaler-sample-00.xml
 $ firefox draft-thaler-sample-00.html
 ```
 
-However the include directive can be used instead by having a "skeleton" file that
-includes the main RST file at an appropriate point.  Thus, conversion to an Internet-Draft
-might be done as follows:
+However the `include directive can be used instead by having a "skeleton" file that
+includes the main RST file, which must be in the same directory, at an appropriate
+point.  Thus, conversion to an Internet-Draft might be done as follows:
 
 ```
 $ rst2rfcxml sample-skeleton.rst -o draft-thaler-sample-00.xml

--- a/lib/rst2rfcxml.cpp
+++ b/lib/rst2rfcxml.cpp
@@ -1023,6 +1023,10 @@ rst2rfcxml::process_line(string current, string next, ostream& output_stream)
         }
 
         filesystem::path relative_path = filesystem::relative(filename);
+        if (relative_path.empty()) {
+            std::cerr << fmt::format("ERROR: {} does not exist", filename) << endl;
+            return 1;
+        }
         filesystem::path input_filename = filesystem::absolute(relative_path);
 
         // Recursively process filename.

--- a/lib/rst2rfcxml.cpp
+++ b/lib/rst2rfcxml.cpp
@@ -1015,6 +1015,13 @@ rst2rfcxml::process_line(string current, string next, ostream& output_stream)
     }
     if (current.starts_with(".. include:: ")) {
         string filename = current.substr(13);
+
+        // Check if filename contains path separators.
+        if (filename.find('/') != string::npos || filename.find('\\') != string::npos) {
+            std::cerr << fmt::format("ERROR: filename {} contains a path separator", filename) << endl;
+            return 1;
+        }
+
         filesystem::path relative_path = filesystem::relative(filename);
         filesystem::path input_filename = filesystem::absolute(relative_path);
 

--- a/test/basic_tests.cpp
+++ b/test/basic_tests.cpp
@@ -29,12 +29,13 @@ constexpr const char* BASIC_PREAMBLE = R"(<?xml version="1.0" encoding="UTF-8"?>
 )";
 
 void
-test_rst2rfcxml(const char* input, const char* expected_output)
+test_rst2rfcxml(const char* input, const char* expected_output, int expected_error = 0)
 {
     rst2rfcxml rst2rfcxml;
     istringstream is(input);
     ostringstream os;
-    rst2rfcxml.process_input_stream(is, os);
+    int error = rst2rfcxml.process_input_stream(is, os);
+    REQUIRE(error == expected_error);
     rst2rfcxml.pop_contexts(0, os);
     string actual_output = os.str();
     REQUIRE(actual_output == expected_output);
@@ -1519,4 +1520,25 @@ TEST_CASE("sample with skeleton", "[basic]")
         (std::istreambuf_iterator<char>(expected_output_file)), std::istreambuf_iterator<char>());
 
     REQUIRE(actual_output == expected_output);
+}
+
+TEST_CASE("include out of directory", "[include]")
+{
+    string expected_output = BASIC_PREAMBLE;
+    test_rst2rfcxml(
+        R"(
+.. include:: ../sample/sample.rst
+)",
+        "",
+        1);
+}
+
+TEST_CASE("include non-existent", "[include]")
+{
+    test_rst2rfcxml(
+        R"(
+.. include:: non-existent.rst
+)",
+        "",
+        1);
 }


### PR DESCRIPTION
Fixes #283

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated instructions now clarify that when using include directives, the main document must reside in the same directory as its skeleton file.
  
- **Bug Fixes**
  - Enhanced error detection to prevent the accidental use of include directives referencing files from outside the allowed directory.
  
- **Tests**
  - Added new checks to ensure proper error notifications are triggered when include directives point to missing or out-of-directory files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->